### PR TITLE
Added WeeWX Installer Package + updated logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+*.tar*

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ the byows_rpi driver.
 
 Optional parameters configurable in the "[BYOWS]" Section:
 
-* loop_interval : How often should the driver generate packets in seconds. Default is 2.5 seconds
-* anemometer_pin : Pin to which anemometer is connected, the DEFAULT is pin 5.
-* rain_bucket_pin : Pin to which rain bucket is connected, the DEFAULT is pin 6.
-* bme280_port : port for sensor bme280. The default value is 1
-* bme280_address : The address for sensor bme280. The default address is 0x77
-* mcp3008_channel : Channel to which wind vane is connected to on MCP3008, The DEFAULT is channel 0
-* anemometer_adjustment : Anemometer adjustment value, the DEFAULT is 1.18
-* bucket_size : Bucket Size in mm, the DEFAULT is 0.2794 mm.
-* anemometer_radius_cm : Anemometer radius in cm, the DEFAULT is 9.0 cm.    
+* **loop_interval** : How often should the driver generate packets in seconds. Default is 2.5 seconds
+* **anemometer_pin** : Pin to which anemometer is connected, the DEFAULT is pin 5.
+* **rain_bucket_pin** : Pin to which rain bucket is connected, the DEFAULT is pin 6.
+* **bme280_port** : port for sensor bme280. The default value is 1
+* **bme280_address** : The address for sensor bme280. The default address is 0x77
+* **mcp3008_channel** : Channel to which wind vane is connected to on MCP3008, The DEFAULT is channel 0
+* **anemometer_adjustment** : Anemometer adjustment value, the DEFAULT is 1.18
+* **bucket_size** : Bucket Size in mm, the DEFAULT is 0.2794 mm.
+* **anemometer_radius_cm** : Anemometer radius in cm, the DEFAULT is 9.0 cm.    

--- a/README.md
+++ b/README.md
@@ -8,87 +8,36 @@ Distributed under terms of the GPLv3
 
 # Installation
 
-Download the byows_rpi.py file and copy it to your weeWX user directory.
-In Debian it is: /usr/share/weewx/user
-
+download the latest release (v0.51) from GitHub into your WeeWx directory
 ```
-wget https://github.com/jardiamj/BYOWS_RPi/blob/master/byows_rpi.py -O /usr/share/weewx/user/byows_rpi.py
+wget https://github.com/ddjlabs/BYOWS_RPi/archive/refs/tags/v0.51.zip
 ```
 
-You could install the driver by using git to clone the project into the weewx user folder:
+Once it is downloaded, run the WeeWX Extension installer. This will install the driver and add the default configuration items to your WeeWX.conf file
 
-git clone https://github.com/jardiamj/BYOWS_RPI.git .
-    
-That will also copy a directory named "files", those files are not necessary for
-the driver to work, they are there for my own documenting purposes.
+```
+sudo ./bin/wee_extension --install v0.51.zip
+```
+
 
 ## Configuration
 
-To enable the byows_rpi driver modify the /etc/weewx/weewx.conf file and change 
-the "station_type" variable to "BYOWS" in the "[Station]" section. Below is a snippet of the
-configured station section.
+To enable the byows_rpi driver modify the weewx.conf file and change 
+the "station_type" variable to "BYOWS" in the "[Station]" section. Configure the driver by looking for the BYOWS stanza at the end of the file.
 
-```plaintext
-[Station]  
-    ...
-    # Set to type of station hardware. There must be a corresponding stanza
-    # in this file with a 'driver' parameter indicating the driver to be used.
-    station_type = BYOWS
-```
-Then add an new section called "[BYOWS]" preferably below the "[Station]" section.
-
-```plaintext
-[BYOWS]
-    # This section is for the Raspberry Pi Bring Your Own Weather Station driver.
-    
-    # [REQUIRED]
-    # The driver to use.
-    driver = user.byows_rpi
-```
 
 If you are using different hardware or connecting them to a different pin or port, you are able
 to add additional variables in the "[BYOWS]" section and thereby overwriting the default values in
-the byows_rpi driver. Please see 
+the byows_rpi driver.
 
+Optional parameters configurable in the "[BYOWS]" Section:
 
-```plaintext
-[BYOWS]
-    # This section is for the Raspberry Pi Bring Your Own Weather Station driver.
-
-    # [REQUIRED]
-    # The driver to use.
-    driver = user.byows_rpi
-
-    # [OPTIONAL]
-    # How often should the driver generate packets in seconds
-    loop_interval = 2.5
-
-    # [OPTIONAL]
-    # Pin to which anemometer is connected, the DEFAULT is pin 5.
-    anemometer_pin = 5
-    
-    # [OPTIONAL]
-    # Pin to which rain bucket is connected, the DEFAULT is pin 6.
-    rain_bucket_pin = 6
-    
-    # [OPTIONAL]
-    # Port and address for sensor bme280, the DEFAULT are port=1 address=0x77
-    bme280_port = 1
-    bme280_address = 0x77
-    
-    # [OPTIONAL]
-    # Channel to which wind vane is connected to on MCP3008, The DEFAULT is channel 0
-    mcp3008_channel = 0
-    
-    # [OPTIONAL]
-    # Anemometer adjustment value, the DEFAULT is 1.18
-    anemometer_adjustment = 1.18
-    
-    # [OPTIONAL]
-    # Bucket Size in mm, the DEFAULT is 0.2794 mm.
-    bucket_size = 0.2794
-    
-    # [OPTIONAL]
-    # Anemometer radious in cm, the DEFAULT is 9.0 cm.    
-    anemometer_radius_cm = 9.0
-```
+* loop_interval : How often should the driver generate packets in seconds. Default is 2.5 seconds
+* anemometer_pin : Pin to which anemometer is connected, the DEFAULT is pin 5.
+* rain_bucket_pin : Pin to which rain bucket is connected, the DEFAULT is pin 6.
+* bme280_port : port for sensor bme280. The default value is 1
+* bme280_address : The address for sensor bme280. The default address is 0x77
+* mcp3008_channel : Channel to which wind vane is connected to on MCP3008, The DEFAULT is channel 0
+* anemometer_adjustment : Anemometer adjustment value, the DEFAULT is 1.18
+* bucket_size : Bucket Size in mm, the DEFAULT is 0.2794 mm.
+* anemometer_radius_cm : Anemometer radius in cm, the DEFAULT is 9.0 cm.    

--- a/bin/user/byows_rpi.py
+++ b/bin/user/byows_rpi.py
@@ -20,6 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
+import logging  #This supports the new WeeWX 4.x logging methodology
 import math
 import syslog
 import time
@@ -36,6 +37,8 @@ import weewx.drivers
 DRIVER_NAME = "BYOWS"
 DRIVER_VERSION = "0.51"
 
+#Initialize the logger for this module
+log = logging.getLogger(__name__)
 
 def loader(config_dict, _):
     return ByowsRpi(**config_dict[DRIVER_NAME])
@@ -45,22 +48,6 @@ def loader(config_dict, _):
 def confeditor_loader():
     return ByowsRpiConfEditor()
 """
-
-
-def logmsg(level, msg):
-    syslog.syslog(level, "BYOWS RPi: %s" % msg)
-
-
-def logdbg(msg):
-    logmsg(syslog.LOG_DEBUG, msg)
-
-
-def loginf(msg):
-    logmsg(syslog.LOG_INFO, msg)
-
-
-def logerr(msg):
-    logmsg(syslog.LOG_ERR, msg)
 
 
 class ByowsRpi(weewx.drivers.AbstractDevice):
@@ -80,8 +67,8 @@ class ByowsRpi(weewx.drivers.AbstractDevice):
         params["anem_adjustment"] = float(stn_dict.get("anemometer_adjustment", 1.18))
         params["bucket_size"] = float(stn_dict.get("bucket_size", 0.2794))
         params["anem_radius_cm"] = float(stn_dict.get("anemometer_radius_cm", 9.0))
-        loginf("using driver %s" % DRIVER_NAME)
-        loginf("driver version is %s" % DRIVER_VERSION)
+        log.info("using driver %s" % DRIVER_NAME)
+        log.info("driver version is %s" % DRIVER_VERSION)
         self.station = ByowsRpiStation(**params)
 
     @property
@@ -133,7 +120,7 @@ class ByowsRpiStation(object):
             pressure = data.pressure
             temperature = data.temperature
         except:
-            logdbg("Error sampling sensor bme280, passing None as data.")
+            log.debug("Error sampling sensor bme280, passing None as data.")
             humidity, pressure, temperature = None, None, None
             pass
         return humidity, pressure, temperature
@@ -286,7 +273,7 @@ class WindGauge(object):
     def read_direction(self):
         wind = round(self.adc.value * 3.3, 1)
         if not wind in self.WIND_VANE_VOLTS:  # keep only good measurements
-            logdbg("Unknown Wind Vane value: %s" % str(wind))
+            log.debug("Unknown Wind Vane value: %s" % str(wind))
             return None
         else:
             return self.WIND_VANE_VOLTS[wind]

--- a/install.py
+++ b/install.py
@@ -1,0 +1,85 @@
+# BYOWS_RPI : WeeWx Driver Implementation of the Build your own WeatherStation Guide Produced by the Raspberry Pi Organization
+# GitHub repo: https://github.com/jardiamj/BYOWS_RPi
+# Copywrite 2019 Jardi Martinez
+# WeeWX Package prepared by Doug Jenkins
+
+import configobj
+from setup import ExtensionInstaller
+from io import StringIO
+
+
+# ----- Extension Information -----
+VERSION = "0.51"
+NAME = 'byows_rpi'
+PACKAGE_DESCRIPTION = 'Bring Your Own Weather Station (BYOWS) Driver for the Raspberry Pi'
+AUTHOR = "Jardi Martinez"
+AUTHOR_EMAIL = "https://github.com/jardiamj/BYOWS_RPi"
+
+# ----- Extension File List -----
+filelist = [('bin/user', ['bin/user/byows_rpi.py'])]
+
+# ----- Configuration details for Weewx.conf -----
+
+driver_config = """
+
+[BYOWS]
+    # This section is for the Raspberry Pi Bring Your Own Weather Station driver.
+
+    # [REQUIRED]
+    # The driver to use.
+    driver = user.byows_rpi
+
+    # [OPTIONAL]
+    # How often should the driver generate packets in seconds
+    loop_interval = 2.5
+
+    # [OPTIONAL]
+    # Pin to which anemometer is connected, the DEFAULT is pin 5.
+    anemometer_pin = 5
+    
+    # [OPTIONAL]
+    # Pin to which rain bucket is connected, the DEFAULT is pin 6.
+    rain_bucket_pin = 6
+    
+    # [OPTIONAL]
+    # Port and address for sensor bme280, the DEFAULT are port=1 address=0x77
+    bme280_port = 1
+    bme280_address = 0x77
+    
+    # [OPTIONAL]
+    # Channel to which wind vane is connected to on MCP3008, The DEFAULT is channel 0
+    mcp3008_channel = 0
+    
+    # [OPTIONAL]
+    # Anemometer adjustment value, the DEFAULT is 1.18
+    anemometer_adjustment = 1.18
+    
+    # [OPTIONAL]
+    # Bucket Size in mm, the DEFAULT is 0.2794 mm.
+    bucket_size = 0.2794
+    
+    # [OPTIONAL]
+    # Anemometer radious in cm, the DEFAULT is 9.0 cm.    
+    anemometer_radius_cm = 9.0
+
+"""
+
+config_dict = configobj.ConfigObj(StringIO(driver_config))
+
+
+# ----- Extension Loader (Using Generic WeeWX Extension Installer) -----
+def loader():
+    return WeeEXTInstaller()
+
+
+class WeeEXTInstaller(ExtensionInstaller):
+    def __init__(self):
+        super(WeeEXTInstaller, self).__init__(
+            version=VERSION,
+            name=NAME,
+            description=PACKAGE_DESCRIPTION,
+            author=AUTHOR,
+            author_email=AUTHOR_EMAIL,
+            files=filelist,
+            config=config_dict
+        )


### PR DESCRIPTION
This Pull request is from my fork of this solution to support a user who was using the BYOWS_RPi solution but was struggling on the install and configuration.

In summary, this request makes the following changes:

1. Added a WeeWX installer file to allow the user to install this driver as an extension. Custom drivers should be installed as extensions in the bin/user folder.
2. updated the logging to the logging package and revised all logging statements. WeeWX went to the standard python logging package in v4.